### PR TITLE
fix: passed request to be used optionally in verifyFn

### DIFF
--- a/packages/app/src/PassportStrategy.ts
+++ b/packages/app/src/PassportStrategy.ts
@@ -19,7 +19,7 @@ export default class FreshbooksStrategy extends OAuth2Strategy {
 		clientId: string,
 		clientSecret: string,
 		callbackURL: string,
-		verify: OAuth2Strategy.VerifyFunction
+		verify: OAuth2Strategy.VerifyFunctionWithRequest
 	) {
 		super(
 			{
@@ -28,6 +28,7 @@ export default class FreshbooksStrategy extends OAuth2Strategy {
 				clientID: clientId,
 				clientSecret,
 				callbackURL,
+				passReqToCallback: true,
 			},
 			verify
 		)

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -7,6 +7,7 @@ import { Client } from '@freshbooks/api'
 import FreshbooksStrategy, { SessionUser } from './PassportStrategy'
 
 const defaultVerifyFn = async (
+	req: Express.Request,
 	token: string,
 	refreshToken: string,
 	profile: object,
@@ -91,7 +92,7 @@ export default function(
 }
 
 export interface Options {
-	verify?: OAuth2Strategy.VerifyFunction
+	verify?: OAuth2Strategy.VerifyFunctionWithRequest
 	sessionOptions?: SessionOptions
 	serializeUser?: <T extends SessionUser>(
 		user: T,


### PR DESCRIPTION
Changed to allow support for passing request in the `verifyFn` for the freshbooks strategy